### PR TITLE
Fixed false empty description alert

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -1201,8 +1201,6 @@ class syntax_plugin_issuetracker extends DokuWiki_Syntax_Plugin
             $ret = '<div class="it__cir_form"><script>
                    // JavaScript Document
                     function chkFormular(frm) {
-
-                        frm.description.value = frm.description.innerHTML;                        
                         
                         if (frm.product.value == "") {
                           alert("Please select a valid product!");


### PR DESCRIPTION
.innerHTML property of empty textarea is empty and *is not* updated upon
typing to the textarea. Thus it's only correct to query .value property
directly.