### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -33,7 +33,7 @@ class action_plugin_issuetracker extends DokuWiki_Action_Plugin {
 /******************************************************************************
 **  Register its handlers with the dokuwiki's event controller
 */
-     function register(&$controller) {
+     function register(Doku_Event_Handler $controller) {
          $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this, '_handle_act', array());
          $controller->register_hook('TPL_ACT_UNKNOWN', 'BEFORE', $this, 'output', array());
                                     //HTML_UPDATEPROFILEFORM_OUTPUT

--- a/syntax.php
+++ b/syntax.php
@@ -42,7 +42,7 @@ class syntax_plugin_issuetracker extends DokuWiki_Syntax_Plugin
 /******************************************************************************/
 /* Handle the match
 */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         $match = substr($match,15,-2); //strip markup from start and end
         //handle params
         $data = array();
@@ -98,7 +98,7 @@ class syntax_plugin_issuetracker extends DokuWiki_Syntax_Plugin
 /******************************************************************************/
 /* Create output
 */
-    function render($mode, &$renderer, $data) {        
+    function render($mode, Doku_Renderer $renderer, $data) {        
         global $ID;
         $project = $data['project']; 
         


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
